### PR TITLE
Re-enable all code climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,0 @@
-version: "2"
-checks:
-  argument-count:
-    enabled: false
-  complex-logic:
-    enabled: false
-  method-complexity:
-    enabled: false


### PR DESCRIPTION
.codeclimate.yml disabled entirely some code climate checks.
It's better to ignore blocks of code individually rather than to disable the checks entirely.